### PR TITLE
Use the modloader logging API

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,6 +5,7 @@ on:
         branches:
             - main
     pull_request:
+    workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,7 +3,7 @@ name: Cargo Build
 on:
     push:
         branches:
-            - "**"
+            - main
     pull_request:
 
 env:
@@ -14,7 +14,7 @@ jobs:
         name: "Build project"
         runs-on: windows-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                 submodules: 'true'
             - run: rustup update stable
@@ -33,7 +33,7 @@ jobs:
             - name: Stage HTML documentation
               run: |
                 Copy-Item -Path target\x86_64-pc-windows-msvc\doc -Destination docs -Recurse
-            - uses: actions/upload-artifact@v4
+            - uses: actions/upload-artifact@v7
               with:
                 name: highfleet_qol
                 path: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 1_163 = []
 
 [dependencies]
-highfleet-mod-api = { git = "https://github.com/logdot/Highfleet-Modloader.git" }
+highfleet-mod-api = { git = "https://github.com/logdot/Highfleet-Modloader.git", tag = "v4.0.0" }
 log = "0.4.28"
 serde = { version = "1.0.221", features = ["derive"] }
 serde_json = "1.0.144"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib"]
 1_163 = []
 
 [dependencies]
+highfleet-mod-api = { git = "https://github.com/logdot/Highfleet-Modloader.git" }
 log = "0.4.28"
 serde = { version = "1.0.221", features = ["derive"] }
 serde_json = "1.0.144"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 
 #![deny(missing_docs)]
 
+highfleet_mod_api::export_logger!();
+
 use std::ffi::{c_char, CStr};
 
 use crate::config::Config;
@@ -10,8 +12,6 @@ pub mod config;
 mod dumpable;
 mod flare_crash;
 mod guns;
-#[cfg(debug_assertions)]
-mod logger;
 mod parts;
 mod plane;
 mod plane_guns;

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,7 +1,0 @@
-use log::{LevelFilter, Log};
-
-#[no_mangle]
-pub fn setup_logger(logger: &'static dyn Log, level: LevelFilter) {
-    log::set_logger(logger).unwrap();
-    log::set_max_level(level);
-}


### PR DESCRIPTION
## Summary

- replace the Rust-ABI `setup_logger` export with the stable modloader logging bridge
- export logging support in release builds as well as debug builds
- pin `highfleet-mod-api` to the published Highfleet-Modloader `v4.0.0` tag
- keep all existing `log::error!`, `warn!`, `info!`, and other call sites unchanged

## Compatibility

The mod continues to load under older modloaders, but logging is only installed when the loader supports `highfleet_mod_setup_v1`.

## Verification

- release check passed for feature `1_151`
- release check passed for feature `1_163`
- both checks resolved `highfleet-mod-api` directly from the public `v4.0.0` tag
